### PR TITLE
Update alfy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "license": "MIT",
   "dependencies": {
     "alfred-notifier": "^0.2.3",
-    "alfy": "^0.7.0"
+    "alfy": "^0.9.1"
   }
 }


### PR DESCRIPTION
It wasn't working with Alfred 4.0. When it was going to install it was looking for the installation in the wrong folders. Just by updating the alfly dependency I was able to make it work with the v4